### PR TITLE
Build mservctl on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+# Create a draft release and attach mservctl binaries
+
+name: Draft release
+
+on:
+  push:
+    branches:
+      - wftest/*
+    tags:
+      - 'v*'
+
+env:
+  BINARY_NAME: mservctl
+  
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, macos-latest ]
+        arch: [ amd64 ]
+        
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+      - name: checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+
+      - name: Build
+        run: |
+          cd mservctl && go build -mod=vendor
+
+      - name: Upload ${{ runner.os }} ${{ matrix.arch }} binary
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.BINARY_NAME }}.${{ runner.os }}.${{ matrix.arch }}
+          path: mservctl/${{ env.BINARY_NAME }}
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: [ build ]
+
+    steps:
+      - uses: actions/create-release@v1
+        id: draft-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ env.BINARY_NAME }}.Linux.amd64
+          
+      - name: attach linux binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.draft-release.outputs.upload_url }}
+          asset_path: ./${{ env.BINARY_NAME }}.Linux.amd64/${{ env.BINARY_NAME }}
+          asset_name: ${{ env.BINARY_NAME }}.linux.amd64
+          asset_content_type: application/octet-stream
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ env.BINARY_NAME }}.macos.amd64
+          
+      - name: attach macos binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.draft-release.outputs.upload_url }}
+          asset_path: ./${{ env.BINARY_NAME }}.macos.amd64/${{ env.BINARY_NAME }}
+          asset_name: ${{ env.BINARY_NAME }}.macos.amd64
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
Workflow is triggerred when a 'v*' tag is pushed. For debugging this, make a branch wftest/* and push.

Creates a draft release and attaches the assets to it.