### PR TITLE
Add some more tooling around the project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Binaries
+mserv
+mservctl
+
+# Makefile things
+/out/
+/tmp/
+
+# Git metadata
+.git
+.gitignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,31 +7,30 @@ on:
     branches:
       - wftest/*
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   BINARY_NAME: mservctl
-  
+
 jobs:
   build:
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
-        arch: [ amd64 ]
-        
+        platform: [ubuntu-latest, macos-latest]
+        arch: [amd64]
+
     runs-on: ${{ matrix.platform }}
-    
+
     steps:
       - name: checkout ${{ github.repository }}
         uses: actions/checkout@v2
 
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: "1.13"
 
       - name: Build
-        run: |
-          cd mservctl && go build -mod=vendor
+        run: make build-cli
 
       - name: Upload ${{ runner.os }} ${{ matrix.arch }} binary
         uses: actions/upload-artifact@v1
@@ -42,7 +41,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [build]
 
     steps:
       - uses: actions/create-release@v1
@@ -57,7 +56,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: ${{ env.BINARY_NAME }}.Linux.amd64
-          
+
       - name: attach linux binary
         uses: actions/upload-release-asset@v1
         env:
@@ -71,7 +70,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: ${{ env.BINARY_NAME }}.macos.amd64
-          
+
       - name: attach macos binary
         uses: actions/upload-release-asset@v1
         env:
@@ -81,4 +80,3 @@ jobs:
           asset_path: ./${{ env.BINARY_NAME }}.macos.amd64/${{ env.BINARY_NAME }}
           asset_name: ${{ env.BINARY_NAME }}.macos.amd64
           asset_content_type: application/octet-stream
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: checkout ${{ github.repository }}
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,20 @@
-.DS_Store
-hack
-plugins
-tmp
-files/mserv-plugin*
-build/bundle.zip
-client/client
+# Binaries/objects
 mserv
-mserv.json
-*.so
-bundle.zip
 mservctl
+*.so
 
+# Makefile things
+/out/
+/tmp/
+
+# macOS
+.DS_Store
+
+# Miscellaneous
+build/bundle.zip
+bundle.zip
+client/client
+files/mserv-plugin*
+hack
+mserv.json
+plugins

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,137 @@
+issues:
+  exclude-use-default: false
+  exclude:
+    - ^exported var `Err[A-Za-z]+` should have comment or be unexported$
+    - ^should have a package comment, unless it's in another file for this package$
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  new-from-rev: origin/master
+
+linters-settings:
+  dogsled:
+    max-blank-identifiers: 2
+
+  dupl:
+    threshold: 50
+
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+
+  errorlint:
+    errorf: true
+
+  gci:
+    local-prefixes: github.com/TykTechnologies/mserv
+
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+
+  godot:
+    capital: true
+    scope: toplevel
+
+  gofmt:
+    simplify: true
+
+  gofumpt:
+    extra-rules: true
+
+  golint:
+    min-confidence: 0
+
+  govet:
+    check-shadowing: true
+    enable-all: true
+
+  lll:
+    line-length: 120
+    tab-width: 2
+
+  maligned:
+    suggest-new: true
+
+  nakedret:
+    max-func-lines: 25
+
+  nestif:
+    min-complexity: 4
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+
+    allow-unused: false
+    allow-leading-space: false
+    require-explanation: true
+    require-specific: true
+
+  unparam:
+    check-exported: true
+
+  whitespace:
+    multi-if: false
+    multi-func: false
+
+  wsl:
+    strict-append: true
+    allow-assign-and-call: true
+    allow-multiline-assign: true
+    allow-cuddle-declarations: false
+    allow-trailing-comment: false
+    force-case-trailing-whitespace: 0
+    force-err-cuddling: true
+    allow-separated-leading-comment: false
+
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - dogsled
+    - dupl
+    - errcheck
+    - errorlint
+    - gci
+    - goconst
+    - gocritic
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - gofumpt
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - maligned
+    - nakedret
+    - nestif
+    - nlreturn
+    - noctx
+    - nolintlint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - wrapcheck
+    - wsl
+
+output:
+  format: tab
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+run:
+  modules-download-mode: readonly
+  timeout: 1m

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,9 @@ ENV TYK_MSERV_CONFIG /etc/mserv/mserv.json
 LABEL Description="Tyk MServ service docker image" Vendor="Tyk" Version=$TYKVERSION
 
 RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends \
-            ca-certificates \
- && apt-get autoremove -y \
- && rm -rf /root/.cache
-
+  && apt-get install --assume-yes --no-install-recommends ca-certificates \
+  && apt-get autoremove --assume-yes \
+  && rm -rf /root/.cache
 
 RUN mkdir -p /opt/mserv/downloads
 RUN mkdir -p /opt/mserv/plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,56 @@
-FROM debian:buster-slim
+FROM golang:1.13 AS builder
+
+# Set some shell options for using pipes and such
+SHELL [ "/bin/bash", "-euo", "pipefail", "-c" ]
+
+# Install common CA certificates to blag later
+RUN apt-get update \
+  && apt-get install --assume-yes --no-install-recommends ca-certificates \
+  && apt-get autoremove --assume-yes \
+  && rm -rf /root/.cache
+
+# Don't call any C code (the 'scratch' base image used later won't have any libraries to reference)
+ENV CGO_ENABLED=0
+
+# Can't use Go modules because of broken vendoring/dependencies in Tyk Gateway v2.9.3 - TODO
+ENV GO111MODULE=off
+
+# Precompile the entire Go standard library into a Docker cache layer: useful for other projects too!
+# cf. https://www.reddit.com/r/golang/comments/hj4n44/improved_docker_go_module_dependency_cache_for/
+RUN go install -ldflags="-buildid= -w" -trimpath -v std
+
+WORKDIR /go/src/github.com/TykTechnologies/mserv
+
+# vvv Can't use Go modules because of broken vendoring/dependencies in Tyk Gateway v2.9.3 - TODO
+# # This will save Go dependencies in the Docker cache, until/unless they change
+# COPY go.mod go.sum ./
+
+# # Download and precompile all third party libraries
+# RUN go mod graph | awk '$1 !~ "@" { print $2 }' | xargs go get -ldflags="-buildid= -w" -trimpath -v
+# ^^^ Can't use Go modules because of broken vendoring/dependencies in Tyk Gateway v2.9.3 - TODO
+
+# Add the sources
+COPY . .
+
+# Compile!
+RUN go build -ldflags="-buildid= -w" -trimpath -v -o /bin/mserv
+
+FROM debian:buster-slim AS runner
+
+# Set some shell options for using pipes and such
+SHELL [ "/bin/bash", "-euo", "pipefail", "-c" ]
 
 ENV TYKVERSION 0.1
 ENV TYK_MSERV_CONFIG /etc/mserv/mserv.json
 
 LABEL Description="Tyk MServ service docker image" Vendor="Tyk" Version=$TYKVERSION
 
-RUN apt-get update \
-  && apt-get install --assume-yes --no-install-recommends ca-certificates \
-  && apt-get autoremove --assume-yes \
-  && rm -rf /root/.cache
-
-RUN mkdir -p /opt/mserv/downloads
-RUN mkdir -p /opt/mserv/plugins
-COPY mserv /opt/mserv/
-
-RUN chmod +x /opt/mserv/mserv
+RUN mkdir -p /opt/mserv/downloads /opt/mserv/plugins
 
 WORKDIR /opt/mserv
 
-ENTRYPOINT ["/opt/mserv/mserv"]
+# Bring common CA certificates and binary over
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /bin/mserv /opt/mserv/mserv
+
+ENTRYPOINT [ "/opt/mserv/mserv" ]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,77 @@
+SHELL := bash
+
+# Default - top level rule is what gets run when you run just `make` without specifying a goal/target.
+.DEFAULT_GOAL := build
+
+.DELETE_ON_ERROR:
+.ONESHELL:
+.SHELLFLAGS := -euo pipefail -c
+
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --warn-undefined-variables
+
+IMAGE_NAME ?= tykio/mserv
+
+ifeq ($(origin .RECIPEPREFIX), undefined)
+  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later.)
+endif
+.RECIPEPREFIX = >
+
+# Adjust the width of the first column by changing the '16' value in the printf pattern.
+help:
+> @grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+  | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}'
+.PHONY: help
+
+all: test lint build ## Test and lint and build.
+test: tmp/.tests-passed.sentinel ## Run tests.
+lint: tmp/.linted.sentinel ## Lint all of the Go code. Will also test.
+build: out/image-id ## Build the mserv Docker image. Will also test and lint.
+.PHONY: all test lint build
+
 check-swagger:
-	which swagger || (GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger)
+> which swagger || (GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger)
 
 swagger: check-swagger
-	GO111MODULE=on go mod vendor && GO111MODULE=off swagger generate spec -o ./doc/swagger.yaml --scan-models -x mservclient -x vendor
+> GO111MODULE=on go mod vendor
+> GO111MODULE=off swagger generate spec -o ./doc/swagger.yaml --scan-models -x mservclient -x vendor
+.PHONY: swagger
 
 serve-swagger: check-swagger
-	swagger serve -F=swagger ./doc/swagger.yaml
+> swagger serve -F=swagger ./doc/swagger.yaml
 
 swagger-client: check-swagger
-	mkdir -p ./mservclient && swagger generate client -f ./doc/swagger.yaml -t ./mservclient
+> mkdir -p ./mservclient
+> swagger generate client -f ./doc/swagger.yaml -t ./mservclient
+
+clean: ## Clean up the temp and output directories, and any built binaries. This will cause everything to get rebuilt.
+> rm -rf ./tmp ./out
+> go clean
+.PHONY: clean
+
+clean-docker: ## Clean up any built Docker images.
+> docker images \
+  --filter=reference=$(IMAGE_NAME) \
+  --no-trunc --quiet | sort -f | uniq | xargs -n 1 docker rmi --force
+> rm -f out/image-id
+.PHONY: clean-docker
+
+# Tests - re-run if any Go files have changes since tmp/.tests-passed.sentinel last touched.
+tmp/.tests-passed.sentinel: $(shell find . -type f -iname "*.go")
+> mkdir -p $(@D)
+> go test ./...
+> touch $@
+
+# Lint - re-run if the tests have been re-run (and so, by proxy, whenever the source files have changed).
+tmp/.linted.sentinel: tmp/.tests-passed.sentinel
+> mkdir -p $(@D)
+> golangci-lint run
+> go vet ./...
+> touch $@
+
+# Docker image - re-build if the lint output is re-run.
+out/image-id: tmp/.linted.sentinel
+> mkdir -p $(@D)
+> image_id="$(IMAGE_NAME):$(shell uuidgen)"
+> DOCKER_BUILDKIT=1 docker build --tag="$${image_id}" .
+> echo "$${image_id}" > out/image-id

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ all: test lint build ## Test and lint and build.
 test: tmp/.tests-passed.sentinel ## Run tests.
 lint: tmp/.linted.sentinel ## Lint all of the Go code. Will also test.
 build: out/image-id ## Build the mserv Docker image. Will also test and lint.
-.PHONY: all test lint build
+build-cli: mservctl/mservctl ## Build the mservctl CLI binary. Will also test and lint.
+.PHONY: all test lint build build-cli
 
 check-swagger:
 > which swagger || (GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger)
@@ -46,6 +47,8 @@ swagger-client: check-swagger
 
 clean: ## Clean up the temp and output directories, and any built binaries. This will cause everything to get rebuilt.
 > rm -rf ./tmp ./out
+> go clean
+> cd mservctl
 > go clean
 .PHONY: clean
 
@@ -75,3 +78,8 @@ out/image-id: tmp/.linted.sentinel
 > image_id="$(IMAGE_NAME):$(shell uuidgen)"
 > DOCKER_BUILDKIT=1 docker build --tag="$${image_id}" .
 > echo "$${image_id}" > out/image-id
+
+# CLI binary - re-build if the lint output is re-run.
+mservctl/mservctl: tmp/.linted.sentinel
+> cd mservctl
+> go build -mod=vendor


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
- Added a Makefile (af78602 019b6c0 82e60fa) and linter config (bf0ff42)
- Updated the Dockerfile to multi-stage build (02c8674) and removed the `apt-get upgrade` call (357b24e - the reasoning is on the commit message)
  - Note: due to several build issues with v2.9.3 of the Tyk Gateway, I couldn't fully leverage caching on the build layers, so each (re)build takes about 20 seconds instead of 3~4 😒 
- Set the GitHub Action for releases to use the new Makefile target (af78602)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Centralising these tasks reduces human error and increases productivity.
Faster builds help to remain in a flow state and maintain concentration.