### PR TITLE
[TT-1802] Clean up Stow locations when deleting middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ mservctl
 build/bundle.zip
 bundle.zip
 client/client
-files/mserv-plugin*
+files/mserv-plugin-*
 hack
 mserv.json
 plugins

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,9 +49,6 @@ linters-settings:
     line-length: 120
     tab-width: 2
 
-  maligned:
-    suggest-new: true
-
   nakedret:
     max-func-lines: 25
 
@@ -107,7 +104,6 @@ linters:
     - govet
     - ineffassign
     - lll
-    - maligned
     - nakedret
     - nestif
     - nlreturn

--- a/api/api.go
+++ b/api/api.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	fmtPluginContainer = "mserv-plugin-%s"
-	moduleName         = "mserv.api"
+	// FmtPluginContainer is a format string for the layout of the container names.
+	FmtPluginContainer = "mserv-plugin-%s"
+
+	moduleName = "mserv.api"
 )
 
 var log = logger.GetLogger(moduleName)
@@ -72,7 +74,7 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 		}
 	}()
 
-	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
+	pluginContainerID := fmt.Sprintf(FmtPluginContainer, bundleName)
 
 	fCont, err := fStore.Container(pluginContainerID)
 	if err != nil {
@@ -178,7 +180,7 @@ func (a *API) HandleNewBundle(filePath string, apiID, bundleName string) (*stora
 
 	log.Info("storing bundle in asset repo")
 
-	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
+	pluginContainerID := fmt.Sprintf(FmtPluginContainer, bundleName)
 	fCont, getErr := fStore.Container(pluginContainerID)
 	if getErr != nil {
 		log.WithField("container-id", pluginContainerID).Warning("container not found, creating")
@@ -324,7 +326,7 @@ func (a *API) StoreBundleOnly(filePath string, apiID, bundleName string) (*stora
 
 	log.Info("file store handle opened, storing bundle in asset repo")
 
-	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
+	pluginContainerID := fmt.Sprintf(FmtPluginContainer, bundleName)
 	fCont, getErr := fStore.Container(pluginContainerID)
 	if getErr != nil {
 		log.WithField("container-id", pluginContainerID).Warning("container not found, creating")

--- a/api/api.go
+++ b/api/api.go
@@ -69,7 +69,12 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 
 		return err
 	}
-	defer fStore.Close()
+
+	defer func() {
+		if err := fStore.Close(); err != nil {
+			log.WithError(err).Error("error while closing file store")
+		}
+	}()
 
 	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
 

--- a/api/api.go
+++ b/api/api.go
@@ -59,10 +59,6 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 		return err
 	}
 
-	if errDMW := a.store.DeleteMW(mw.UID); errDMW != nil {
-		return fmt.Errorf("could not delete middleware from store: %w", errDMW)
-	}
-
 	fStore, err := GetFileStore()
 	if err != nil {
 		log.WithError(err).Error("failed to get file handle")
@@ -122,7 +118,11 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 
 	// HACK: workaround for https://github.com/graymeta/stow/issues/239 - ^^^
 
-	return fStore.RemoveContainer(pluginContainerID)
+	if errRC := fStore.RemoveContainer(pluginContainerID); errRC != nil {
+		return fmt.Errorf("could not remove container '%s': %w", pluginContainerID, errRC)
+	}
+
+	return a.store.DeleteMW(mw.UID)
 }
 
 func (a *API) HandleNewBundle(filePath string, apiID, bundleName string) (*storage.MW, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -400,7 +400,7 @@ func GetFileStore() (stow.Location, error) {
 	}
 
 	switch fsCfg.Kind {
-	case "local":
+	case local.Kind:
 		log.WithField("path", fsCfg.Local.ConfigKeyPath).Info("detected local store")
 
 		// Dialling stow/local will fail if the base directory doesn't already exist
@@ -408,13 +408,13 @@ func GetFileStore() (stow.Location, error) {
 			return nil, fmt.Errorf("%w: %s", ErrCreateLocal, fsCfg.Local.ConfigKeyPath)
 		}
 
-		return stow.Dial("local", stow.ConfigMap{
+		return stow.Dial(local.Kind, stow.ConfigMap{
 			local.ConfigKeyPath: fsCfg.Local.ConfigKeyPath,
 		})
-	case "s3":
+	case s3.Kind:
 		log.Info("detected s3 store")
 
-		return stow.Dial("s3", stow.ConfigMap{
+		return stow.Dial(s3.Kind, stow.ConfigMap{
 			s3.ConfigAccessKeyID: fsCfg.S3.ConfigAccessKeyID,
 			s3.ConfigRegion:      fsCfg.S3.ConfigRegion,
 			s3.ConfigSecretKey:   fsCfg.S3.ConfigSecretKey,

--- a/api/api.go
+++ b/api/api.go
@@ -24,10 +24,12 @@ import (
 	"github.com/TykTechnologies/mserv/util/storage/errors"
 )
 
-var (
-	moduleName = "mserv.api"
-	log        = logger.GetLogger(moduleName)
+const (
+	fmtPluginContainer = "mserv-plugin-%s"
+	moduleName         = "mserv.api"
 )
+
+var log = logger.GetLogger(moduleName)
 
 func NewAPI(store storage.MservStore) *API {
 	return &API{store: store}
@@ -112,10 +114,11 @@ func (a *API) HandleNewBundle(filePath string, apiID, bundleName string) (*stora
 	pluginPath := path.Join(bdl.Path, fName)
 
 	log.Info("storing bundle in asset repo")
-	pluginContainerID := "mserv-plugin-" + bundleName
+
+	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
 	fCont, getErr := fStore.Container(pluginContainerID)
 	if getErr != nil {
-		log.Warning("container not found, creating")
+		log.WithField("container-id", pluginContainerID).Warning("container not found, creating")
 		fCont, err = fStore.CreateContainer(pluginContainerID)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't fetch container: %s, couldn't create container: %s", getErr.Error(), err.Error())
@@ -257,7 +260,8 @@ func (a *API) StoreBundleOnly(filePath string, apiID, bundleName string) (*stora
 	defer fStore.Close()
 
 	log.Info("file store handle opened, storing bundle in asset repo")
-	pluginContainerID := "mserv-plugin-" + bundleName
+
+	pluginContainerID := fmt.Sprintf(fmtPluginContainer, bundleName)
 	fCont, getErr := fStore.Container(pluginContainerID)
 	if getErr != nil {
 		log.WithField("container-id", pluginContainerID).Warning("container not found, creating")

--- a/api/api.go
+++ b/api/api.go
@@ -71,8 +71,8 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 	}
 
 	defer func() {
-		if err := fStore.Close(); err != nil {
-			log.WithError(err).Error("error while closing file store")
+		if errFC := fStore.Close(); errFC != nil {
+			log.WithError(errFC).Error("error while closing file store")
 		}
 	}()
 
@@ -104,18 +104,18 @@ func (a *API) HandleDeleteBundle(bundleName string) error {
 	fsCfg := config.GetConf().Mserv.FileStore
 
 	if fsCfg.Kind == local.Kind {
-		prevWD, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("could not get current working directory: %w", err)
+		prevWD, errWD := os.Getwd()
+		if errWD != nil {
+			return fmt.Errorf("could not get current working directory: %w", errWD)
 		}
 
-		if err := os.Chdir(fsCfg.Local.ConfigKeyPath); err != nil {
-			return fmt.Errorf("could not change current working directory: %w", err)
+		if errCD := os.Chdir(fsCfg.Local.ConfigKeyPath); errCD != nil {
+			return fmt.Errorf("could not change current working directory: %w", errCD)
 		}
 
 		defer func() {
-			if err := os.Chdir(prevWD); err != nil {
-				log.WithError(err).Error("could not revert to previous working directory")
+			if errPD := os.Chdir(prevWD); errPD != nil {
+				log.WithError(errPD).WithField("dir", prevWD).Error("could not revert to previous working directory")
 			}
 		}()
 	}

--- a/http_funcs/api_handlers.go
+++ b/http_funcs/api_handlers.go
@@ -182,8 +182,7 @@ func (h *HttpServ) DeleteMW(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.api.HandleDeleteBundle(id)
-	if err != nil {
+	if err := h.api.HandleDeleteBundle(id); err != nil {
 		h.HandleError(err, w, r)
 		return
 	}

--- a/http_funcs/api_handlers_add_test.go
+++ b/http_funcs/api_handlers_add_test.go
@@ -1,109 +1,13 @@
 package http_funcs_test
 
 import (
-	"archive/zip"
-	"bytes"
-	"crypto/rand"
-	"encoding/json"
-	"io"
 	"io/ioutil"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/matryer/is"
-
-	config "github.com/TykTechnologies/mserv/conf"
-	"github.com/TykTechnologies/mserv/http_funcs"
-	"github.com/TykTechnologies/mserv/util/storage/mock"
 )
-
-type addMWTestCase struct {
-	testBodyBytes  func(*testing.T) []byte
-	expectedStatus int
-}
-
-var addMWTestCases = map[string]addMWTestCase{
-	"Compressed (ZIP) upload is OK": {
-		testBodyBytes:  compressedTestData,
-		expectedStatus: http.StatusOK,
-	},
-	"Uncompressed upload is not OK": {
-		testBodyBytes:  uncompressedTestData,
-		expectedStatus: http.StatusUnprocessableEntity,
-	},
-	"Uncompressed manifest by itself (no Python) is not OK": {
-		testBodyBytes:  uncompressedJSONTestData,
-		expectedStatus: http.StatusUnprocessableEntity,
-	},
-	"Uncompressed Python by itself (no manifest JSON) is not OK": {
-		testBodyBytes:  uncompressedPythonTestData,
-		expectedStatus: http.StatusUnprocessableEntity,
-	},
-	"Random byte stream can not be classified/detected": {
-		testBodyBytes:  randomByteStream,
-		expectedStatus: http.StatusUnsupportedMediaType,
-	},
-}
-
-func setupServerAndTempDir(t *testing.T) (*http_funcs.HttpServ, string) {
-	t.Helper()
-	is := is.New(t)
-
-	// Prepare the config file and the plugin uploads directory
-	testTemp := t.TempDir()
-	t.Logf("operating out of '%s' directory", testTemp)
-
-	cfgFilePath := filepath.Join(testTemp, "mserv.conf")
-	is.NoErr(os.Setenv("TYK_MSERV_CONFIG", cfgFilePath)) // could not set config file location in environment
-
-	cfg := config.Config{}
-	cfg.Mserv.FileStore = &config.FileStorage{}
-	cfg.Mserv.FileStore.Kind = "local"
-	cfg.Mserv.FileStore.Local = &config.LocalStore{}
-	cfg.Mserv.FileStore.Local.ConfigKeyPath = filepath.Join(testTemp, "files")
-	cfg.Mserv.MiddlewarePath = filepath.Join(testTemp, "middleware")
-	cfg.Mserv.PluginDir = filepath.Join(testTemp, "plugins")
-	cfg.Mserv.RetainUploads = false // would default to false anyway, but we set it explicitly for these tests
-
-	fileCountPath := filepath.Join(cfg.Mserv.MiddlewarePath, "plugins")
-	is.NoErr(os.MkdirAll(fileCountPath, 0o700)) // could not prepare upload directory
-
-	cfgBytes, err := json.Marshal(cfg)
-	is.NoErr(err)                                            // could not marshal config struct
-	is.NoErr(ioutil.WriteFile(cfgFilePath, cfgBytes, 0o600)) // could not write config out to file
-
-	// Return a new server, and the upload path to check (this is a workaround for config.GetConf() only running once per
-	// package call, and not on every call)
-	return http_funcs.NewServer("http://mserv.io", &mock.Storage{}), fileCountPath
-}
-
-func prepareRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.Request {
-	t.Helper()
-	is := is.New(t)
-
-	// Get the attachment ready
-	reqBody := &bytes.Buffer{}
-	writer := multipart.NewWriter(reqBody)
-	part, err := writer.CreateFormFile(http_funcs.UploadFormField, "attachment.zip")
-	is.NoErr(err) // could not create part for file being uploaded
-
-	size, err := part.Write(getAttachment(t))
-	is.NoErr(err) // could not write test attachment file bytes to multipart
-
-	is.NoErr(writer.Close()) // could not close multipart writer cleanly
-	t.Logf("attachment size is '%d' bytes", size)
-
-	// Get the request ready with the attachment
-	req := httptest.NewRequest(http.MethodPost, "http://mserv.io/api/mw", reqBody)
-	req.Header.Add("Content-Type", writer.FormDataContentType())
-	is.NoErr(req.ParseForm()) // could not parse form on HTTP request
-
-	return req
-}
 
 func TestAddMWStoreBundleOnly(t *testing.T) {
 	is := is.New(t)
@@ -161,78 +65,4 @@ func TestAddMWHandleNewBundle(t *testing.T) {
 		is.NoErr(err)                               // could not read 'config.Mserv.MiddlewarePath+"/plugins"' directory
 		is.Equal(len(startCount), len(finishCount)) // should not leave uploads behind unless configured to do so
 	})
-}
-
-func getCompressed(t *testing.T, flat bool, files ...string) []byte {
-	t.Helper()
-	is := is.New(t)
-
-	buf := bytes.Buffer{}
-	w := zip.NewWriter(&buf)
-
-	for _, file := range files {
-		var (
-			f   io.Writer
-			err error
-		)
-
-		if flat {
-			f, err = w.Create(filepath.Base(file))
-		} else {
-			f, err = w.Create(file)
-		}
-		is.NoErr(err) // could not create file in zip.Writer
-
-		_, err = f.Write(getUncompressed(t, file))
-		is.NoErr(err) // could not write body of file into zip.Writer
-	}
-
-	is.NoErr(w.Close()) // could not close zip.Writer
-
-	return buf.Bytes()
-}
-
-func getUncompressed(t *testing.T, files ...string) []byte {
-	t.Helper()
-	is := is.New(t)
-
-	buf := bytes.Buffer{}
-
-	for _, file := range files {
-		body, err := ioutil.ReadFile(file) //nolint:gosec // File paths are hard-coded to these test helpers
-		is.NoErr(err)                      // could not read file
-
-		_, err = buf.Write(body)
-		is.NoErr(err) // could not write body of file into buffer
-	}
-
-	return buf.Bytes()
-}
-
-func compressedTestData(t *testing.T) []byte {
-	return getCompressed(t, true, "testdata/uncompressed/manifest.json", "testdata/uncompressed/middleware.py")
-}
-
-func uncompressedTestData(t *testing.T) []byte {
-	return getUncompressed(t, "testdata/uncompressed/manifest.json", "testdata/uncompressed/middleware.py")
-}
-
-func uncompressedJSONTestData(t *testing.T) []byte {
-	return getUncompressed(t, "testdata/uncompressed/manifest.json")
-}
-
-func uncompressedPythonTestData(t *testing.T) []byte {
-	return getUncompressed(t, "testdata/uncompressed/middleware.py")
-}
-
-func randomByteStream(t *testing.T) []byte {
-	t.Helper()
-	is := is.New(t)
-
-	bytes := make([]byte, 1024)
-	count, err := rand.Read(bytes)
-	is.NoErr(err)
-	is.Equal(1024, count)
-
-	return bytes
 }

--- a/http_funcs/api_handlers_add_test.go
+++ b/http_funcs/api_handlers_add_test.go
@@ -4,14 +4,17 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/matryer/is"
+
+	config "github.com/TykTechnologies/mserv/conf"
 )
 
 func TestAddMWStoreBundleOnly(t *testing.T) {
 	is := is.New(t)
-	srv, _ := setupServerAndTempDir(t)
+	srv := setupServerAndTempDir(t)
 
 	for name, tc := range addMWTestCases {
 		name, tc := name, tc
@@ -38,9 +41,10 @@ func TestAddMWStoreBundleOnly(t *testing.T) {
 
 func TestAddMWHandleNewBundle(t *testing.T) {
 	is := is.New(t)
-	srv, fileCountPath := setupServerAndTempDir(t)
+	srv := setupServerAndTempDir(t)
 
 	t.Run("Compressed (ZIP) upload is OK", func(t *testing.T) {
+		fileCountPath := filepath.Join(config.GetConf().Mserv.MiddlewarePath, "plugins")
 		startCount, err := ioutil.ReadDir(fileCountPath)
 		is.NoErr(err) // could not read 'config.Mserv.MiddlewarePath+"/plugins"' directory
 

--- a/http_funcs/api_handlers_add_test.go
+++ b/http_funcs/api_handlers_add_test.go
@@ -19,7 +19,7 @@ func TestAddMWStoreBundleOnly(t *testing.T) {
 	for name, tc := range addMWTestCases {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
-			req := prepareRequest(t, tc.testBodyBytes)
+			req := prepareAddRequest(t, tc.testBodyBytes)
 			req.Form.Add("store_only", "true") // target the 'StoreBundleOnly' code path
 
 			// Handle the request
@@ -48,7 +48,7 @@ func TestAddMWHandleNewBundle(t *testing.T) {
 		startCount, err := ioutil.ReadDir(fileCountPath)
 		is.NoErr(err) // could not read 'config.Mserv.MiddlewarePath+"/plugins"' directory
 
-		req := prepareRequest(t, compressedTestData)
+		req := prepareAddRequest(t, compressedTestData)
 		req.Form.Add("store_only", "false") // target the 'HandleNewBundle' code path
 
 		// Handle the request

--- a/http_funcs/api_handlers_delete_test.go
+++ b/http_funcs/api_handlers_delete_test.go
@@ -1,0 +1,1 @@
+package http_funcs_test

--- a/http_funcs/api_handlers_delete_test.go
+++ b/http_funcs/api_handlers_delete_test.go
@@ -1,1 +1,88 @@
 package http_funcs_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+
+	config "github.com/TykTechnologies/mserv/conf"
+	"github.com/TykTechnologies/mserv/models"
+)
+
+func TestDeleteMW(t *testing.T) {
+	is := is.New(t)
+	srv := setupServerAndTempDir(t)
+
+	t.Run("Deleted middleware does not leave stow.Container behind", func(t *testing.T) {
+		// Paths to check for things to make sure the handlers are behaving and cleaning up properly
+		fileCountPath := filepath.Join(config.GetConf().Mserv.MiddlewarePath, "plugins")
+		localContainerPath := config.GetConf().Mserv.FileStore.Local.ConfigKeyPath
+
+		startFileCount, err := ioutil.ReadDir(fileCountPath)
+		is.NoErr(err) // could not read 'config.Mserv.MiddlewarePath+"/plugins"' directory
+
+		addReq := prepareAddRequest(t, compressedTestData)
+		addReq.Form.Add("store_only", "false") // target the 'HandleNewBundle' code path
+
+		// Handle the AddMW request
+		w := httptest.NewRecorder()
+		srv.AddMW(w, addReq)
+
+		// Parse the AddMW response
+		addResp := w.Result()
+		defer is.NoErr(addResp.Body.Close())        // could not close AddMW response body cleanly
+		is.Equal(http.StatusOK, addResp.StatusCode) // expected response status does not equal actual from AddMW
+
+		addBod, errRead := ioutil.ReadAll(addResp.Body)
+		is.NoErr(errRead) // could not read response body
+		t.Logf("response from %s %s: %s %s", addReq.Method, addReq.URL, addResp.Status, addBod)
+
+		// Confirm that stow created one new container in this test's temp directory
+		startContainerCount, err := ioutil.ReadDir(localContainerPath)
+		is.NoErr(err)                         // could not read directory
+		is.Equal(1, len(startContainerCount)) // should have one stow.Container after calling AddMW
+
+		// Get ID of added middleware
+		payload := &models.Payload{}
+		is.NoErr(json.Unmarshal(addBod, payload)) // could not unmarshal response payload
+
+		internalPayload, ok := payload.Payload.(map[string]interface{})
+		is.True(ok) // could not assert type on internal payload
+
+		addedMWID, hasID := internalPayload["BundleID"]
+		is.True(hasID) // internal payload does not contain "BundleID"
+
+		sAddedMWID, ok := addedMWID.(string)
+		is.True(ok) // could not assert type on added middleware ID
+		t.Logf("ID of newly-added middleware: '%s'", sAddedMWID)
+
+		// Do the DeleteMW things
+		deleteReq := prepareDeleteRequest(t, sAddedMWID)
+		w = httptest.NewRecorder() // reinitialise
+		srv.DeleteMW(w, deleteReq)
+
+		// Parse the DeleteMW response
+		deleteResp := w.Result()
+		defer is.NoErr(deleteResp.Body.Close())        // could not close DeleteMW response body cleanly
+		is.Equal(http.StatusOK, deleteResp.StatusCode) // expected response status does not equal actual from DeleteMW
+
+		deleteBod, errRead := ioutil.ReadAll(deleteResp.Body)
+		is.NoErr(errRead) // could not read response body
+		t.Logf("response from %s %s: %s %s", deleteReq.Method, deleteReq.URL, deleteResp.Status, deleteBod)
+
+		finishFileCount, err := ioutil.ReadDir(fileCountPath)
+		is.NoErr(err) // could not read 'config.Mserv.MiddlewarePath+"/plugins"' directory
+
+		is.Equal(len(startFileCount), len(finishFileCount)) // should not leave uploads behind unless configured to do so
+
+		// Confirm that DeleteMW directed stow to clean up after itself
+		finishContainerCount, err := ioutil.ReadDir(localContainerPath)
+		is.NoErr(err)                          // could not read directory
+		is.Equal(0, len(finishContainerCount)) // should have zero stow.Container after calling DeleteMW
+	})
+}

--- a/http_funcs/api_handlers_test.go
+++ b/http_funcs/api_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/matryer/is"
 
 	config "github.com/TykTechnologies/mserv/conf"
@@ -83,7 +85,7 @@ func setupServerAndTempDir(t *testing.T) *http_funcs.HttpServ {
 	return http_funcs.NewServer("http://mserv.io", &mock.Storage{})
 }
 
-func prepareRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.Request {
+func prepareAddRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.Request {
 	t.Helper()
 	is := is.New(t)
 
@@ -103,6 +105,16 @@ func prepareRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.R
 	req := httptest.NewRequest(http.MethodPost, "http://mserv.io/api/mw", reqBody)
 	req.Header.Add("Content-Type", writer.FormDataContentType())
 	is.NoErr(req.ParseForm()) // could not parse form on HTTP request
+
+	return req
+}
+
+func prepareDeleteRequest(t *testing.T, id string) *http.Request {
+	t.Helper()
+
+	path := fmt.Sprintf("http://mserv.io/api/mw/%s", id)
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	req = mux.SetURLVars(req, map[string]string{"id": id})
 
 	return req
 }

--- a/http_funcs/api_handlers_test.go
+++ b/http_funcs/api_handlers_test.go
@@ -49,7 +49,7 @@ var addMWTestCases = map[string]addMWTestCase{
 	},
 }
 
-func setupServerAndTempDir(t *testing.T) (*http_funcs.HttpServ, string) {
+func setupServerAndTempDir(t *testing.T) *http_funcs.HttpServ {
 	t.Helper()
 	is := is.New(t)
 
@@ -76,9 +76,11 @@ func setupServerAndTempDir(t *testing.T) (*http_funcs.HttpServ, string) {
 	is.NoErr(err)                                            // could not marshal config struct
 	is.NoErr(ioutil.WriteFile(cfgFilePath, cfgBytes, 0o600)) // could not write config out to file
 
-	// Return a new server, and the upload path to check (this is a workaround for config.GetConf() only running once per
-	// package call, and not on every call)
-	return http_funcs.NewServer("http://mserv.io", &mock.Storage{}), fileCountPath
+	// Make sure the config in use is current and aligned with what was just established here
+	config.Reload()
+
+	// Return a new server
+	return http_funcs.NewServer("http://mserv.io", &mock.Storage{})
 }
 
 func prepareRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.Request {

--- a/http_funcs/api_handlers_test.go
+++ b/http_funcs/api_handlers_test.go
@@ -1,0 +1,180 @@
+package http_funcs_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matryer/is"
+
+	config "github.com/TykTechnologies/mserv/conf"
+	"github.com/TykTechnologies/mserv/http_funcs"
+	"github.com/TykTechnologies/mserv/util/storage/mock"
+)
+
+type addMWTestCase struct {
+	testBodyBytes  func(*testing.T) []byte
+	expectedStatus int
+}
+
+var addMWTestCases = map[string]addMWTestCase{
+	"Compressed (ZIP) upload is OK": {
+		testBodyBytes:  compressedTestData,
+		expectedStatus: http.StatusOK,
+	},
+	"Uncompressed upload is not OK": {
+		testBodyBytes:  uncompressedTestData,
+		expectedStatus: http.StatusUnprocessableEntity,
+	},
+	"Uncompressed manifest by itself (no Python) is not OK": {
+		testBodyBytes:  uncompressedJSONTestData,
+		expectedStatus: http.StatusUnprocessableEntity,
+	},
+	"Uncompressed Python by itself (no manifest JSON) is not OK": {
+		testBodyBytes:  uncompressedPythonTestData,
+		expectedStatus: http.StatusUnprocessableEntity,
+	},
+	"Random byte stream can not be classified/detected": {
+		testBodyBytes:  randomByteStream,
+		expectedStatus: http.StatusUnsupportedMediaType,
+	},
+}
+
+func setupServerAndTempDir(t *testing.T) (*http_funcs.HttpServ, string) {
+	t.Helper()
+	is := is.New(t)
+
+	// Prepare the config file and the plugin uploads directory
+	testTemp := t.TempDir()
+	t.Logf("operating out of '%s' directory", testTemp)
+
+	cfgFilePath := filepath.Join(testTemp, "mserv.conf")
+	is.NoErr(os.Setenv("TYK_MSERV_CONFIG", cfgFilePath)) // could not set config file location in environment
+
+	cfg := config.Config{}
+	cfg.Mserv.FileStore = &config.FileStorage{}
+	cfg.Mserv.FileStore.Kind = "local"
+	cfg.Mserv.FileStore.Local = &config.LocalStore{}
+	cfg.Mserv.FileStore.Local.ConfigKeyPath = filepath.Join(testTemp, "files")
+	cfg.Mserv.MiddlewarePath = filepath.Join(testTemp, "middleware")
+	cfg.Mserv.PluginDir = filepath.Join(testTemp, "plugins")
+	cfg.Mserv.RetainUploads = false // would default to false anyway, but we set it explicitly for these tests
+
+	fileCountPath := filepath.Join(cfg.Mserv.MiddlewarePath, "plugins")
+	is.NoErr(os.MkdirAll(fileCountPath, 0o700)) // could not prepare upload directory
+
+	cfgBytes, err := json.Marshal(cfg)
+	is.NoErr(err)                                            // could not marshal config struct
+	is.NoErr(ioutil.WriteFile(cfgFilePath, cfgBytes, 0o600)) // could not write config out to file
+
+	// Return a new server, and the upload path to check (this is a workaround for config.GetConf() only running once per
+	// package call, and not on every call)
+	return http_funcs.NewServer("http://mserv.io", &mock.Storage{}), fileCountPath
+}
+
+func prepareRequest(t *testing.T, getAttachment func(*testing.T) []byte) *http.Request {
+	t.Helper()
+	is := is.New(t)
+
+	// Get the attachment ready
+	reqBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(reqBody)
+	part, err := writer.CreateFormFile(http_funcs.UploadFormField, "attachment.zip")
+	is.NoErr(err) // could not create part for file being uploaded
+
+	size, err := part.Write(getAttachment(t))
+	is.NoErr(err) // could not write test attachment file bytes to multipart
+
+	is.NoErr(writer.Close()) // could not close multipart writer cleanly
+	t.Logf("attachment size is '%d' bytes", size)
+
+	// Get the request ready with the attachment
+	req := httptest.NewRequest(http.MethodPost, "http://mserv.io/api/mw", reqBody)
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	is.NoErr(req.ParseForm()) // could not parse form on HTTP request
+
+	return req
+}
+
+func getCompressed(t *testing.T, flat bool, files ...string) []byte {
+	t.Helper()
+	is := is.New(t)
+
+	buf := bytes.Buffer{}
+	w := zip.NewWriter(&buf)
+
+	for _, file := range files {
+		var (
+			f   io.Writer
+			err error
+		)
+
+		if flat {
+			f, err = w.Create(filepath.Base(file))
+		} else {
+			f, err = w.Create(file)
+		}
+		is.NoErr(err) // could not create file in zip.Writer
+
+		_, err = f.Write(getUncompressed(t, file))
+		is.NoErr(err) // could not write body of file into zip.Writer
+	}
+
+	is.NoErr(w.Close()) // could not close zip.Writer
+
+	return buf.Bytes()
+}
+
+func getUncompressed(t *testing.T, files ...string) []byte {
+	t.Helper()
+	is := is.New(t)
+
+	buf := bytes.Buffer{}
+
+	for _, file := range files {
+		body, err := ioutil.ReadFile(file) //nolint:gosec // File paths are hard-coded to these test helpers
+		is.NoErr(err)                      // could not read file
+
+		_, err = buf.Write(body)
+		is.NoErr(err) // could not write body of file into buffer
+	}
+
+	return buf.Bytes()
+}
+
+func compressedTestData(t *testing.T) []byte {
+	return getCompressed(t, true, "testdata/uncompressed/manifest.json", "testdata/uncompressed/middleware.py")
+}
+
+func uncompressedTestData(t *testing.T) []byte {
+	return getUncompressed(t, "testdata/uncompressed/manifest.json", "testdata/uncompressed/middleware.py")
+}
+
+func uncompressedJSONTestData(t *testing.T) []byte {
+	return getUncompressed(t, "testdata/uncompressed/manifest.json")
+}
+
+func uncompressedPythonTestData(t *testing.T) []byte {
+	return getUncompressed(t, "testdata/uncompressed/middleware.py")
+}
+
+func randomByteStream(t *testing.T) []byte {
+	t.Helper()
+	is := is.New(t)
+
+	bytes := make([]byte, 1024)
+	count, err := rand.Read(bytes)
+	is.NoErr(err)
+	is.Equal(1024, count)
+
+	return bytes
+}

--- a/util/conf/config.go
+++ b/util/conf/config.go
@@ -24,6 +24,13 @@ type GlobalConf struct{}
 
 var gConf *GlobalConf
 
+// Flush will reinitialise/forget any config data already read.
+func Flush() {
+	confDat = make([]byte, 0)
+
+	log.Debug("flushed config bytes")
+}
+
 // ReadConf provides the raw data from the config file.
 // The config file's location can be set via an environment variable `TYK_MSERV_CONFIG`, and if not specified defaults
 // to `/etc/tyk-mserv/config.json`.

--- a/util/storage/mock/mock.go
+++ b/util/storage/mock/mock.go
@@ -10,7 +10,7 @@ type Storage struct{}
 
 // GetMWByID is a test mock.
 func (s *Storage) GetMWByID(id string) (*storage.MW, error) {
-	panic("TODO: Implement")
+	return &storage.MW{UID: id}, nil
 }
 
 // GetMWByAPIID is a test mock.
@@ -39,7 +39,7 @@ func (s *Storage) UpdateMW(mw *storage.MW) (string, error) {
 
 // DeleteMW is a test mock.
 func (s *Storage) DeleteMW(id string) error {
-	panic("TODO: Implement")
+	return nil
 }
 
 // InitMservStore is a test mock.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
The handler to delete middleware was not cleaning up containers for either of the two different kinds of stow location in use by MServ i.e. `local` and `s3`.

### `api` package

#### `(api.API).HandleDeleteBundle(...)`

- added calls for the following:
  - `stow.Walk` removes each item from the container (necessary for S3) (10a677490818813984a48905693596e403526dea)
  - `(stow.Location).RemoveContainer` removes the empty container itself (d63b6d4921b612a77491c177c76aad9db6095ef3)
  - `os.Chdir` is necessary to workaround a shortcoming in how stow handles `local` containers: https://github.com/graymeta/stow/issues/239 (aeb5c3659bdb7c23a31a376a576fe35b6d89d97d)
- refactored to get middleware from store at start of handler but not delete from store until the end, to reduce overall chance of failure leaving orphaned middlewares behind (de2b1ebcbc5fbfe277da0f2be9474b8ee00e22ac)

#### General

- exported the `FmtPluginContainer` format string used for container name layouts (94705cbfdf45035dd2e456919e7e76a5da649c66, 81b5a701c039c3daeafd65e052bf11e9d82fe68b)
- used exported `stow.Kind` consts in `GetFileStore()` rather than hard-coded strings (18cf3d3c73877f94d78b2f97b9e81ae749b2e19e)

### `http_funcs` package

- added `TestDeleteMW` to cover the existing and updated functionality of the API's delete handler (1cb44d80f2ae76cd1f8ba81ffbfda3ecd0b39183)
- broke tests and their helpers down across several files, instead of just one (cba2f6ccbd9e95174a0bf4abf87b3807b2a4b0da)

### `conf` package

- refactored to add a `Reload()` func which will flush the current config and re-read data (c8e1a32dbcecd0b1c0c5e818cf1efb71c5645297)

### `util/conf` package

- added `Flush()` to facilitate `conf.Reload()`

### `util/storage/mock` package

- implemented some funcs necessary for increased test coverage

### Miscellaneous

- disabled `maligned` in the `golangci-lint` config file, as it has since moved into `go vet` (8cfe5ee16b3b30a741786aa06a76312fdbcaeccb)

## Related Issue
<!-- This project will only accept PRs related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
[TT-1802](https://tyktech.atlassian.net/browse/TT-1802).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
End users don't want S3 buckets left lying around after they delete a middleware.

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Added `TestDeleteMW`, and ran some integration tests on my local, to cover both `local` and `s3` kinds of stow locations.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor` in applicable directories.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [x] `golangci-lint run`
