### PR TITLE
TT-448: add mservctl update command

### DIFF
--- a/mservctl/cmd/update.go
+++ b/mservctl/cmd/update.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/TykTechnologies/mserv/mservclient/client/mw"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:     "update",
+	Short:   "Updates a middleware on mserv",
+	Long:    "Updates a middleware by ID",
+	Example: `mservctl update 13b0eb10-419f-40ef-838d-6d26bb2eeaa8 /path/to/bundle.zip`,
+	Args:    cobra.ExactArgs(2),
+	Run:     updateMiddleware,
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+}
+
+func updateMiddleware(cmd *cobra.Command, args []string) {
+	file, err := os.Open(args[1])
+	if err != nil {
+		log.WithError(err).Error("Couldn't open the bundle file")
+		return
+	}
+	defer file.Close()
+
+	params := mw.NewMwUpdateParams().WithID(args[0]).WithUploadFile(file)
+
+	resp, err := mservapi.Mw.MwUpdate(params, defaultAuth())
+	if err != nil {
+		log.WithError(err).Error("Couldn't update middleware")
+		return
+	}
+
+	cmd.Printf("Middleware uploaded successfully, ID: %s\n", resp.GetPayload().Payload.BundleID)
+}

--- a/mservctl/cmd/update.go
+++ b/mservctl/cmd/update.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -30,7 +31,7 @@ func updateMiddleware(cmd *cobra.Command, args []string) {
 	}
 	defer file.Close()
 
-	params := mw.NewMwUpdateParams().WithID(args[0]).WithUploadFile(file)
+	params := mw.NewMwUpdateParams().WithID(args[0]).WithUploadFile(file).WithTimeout(120 * time.Second)
 
 	resp, err := mservapi.Mw.MwUpdate(params, defaultAuth())
 	if err != nil {


### PR DESCRIPTION
## Description
While mserv supports updating bundles, the mservctl client does not currently implement this functionality. This PR implements it by adding an `mservctl update` command to the tool.

Usage:
`mservctl update 9c9ecec1-8f98-4c3f-88cd-ca3c27599e6b bundle.zip`

## Related Issue
#15 

## Motivation and Context
Currently, mservctl only allows us to delete and recreate plugin entries each time we make a code update to one of our plugins. Our plugins are shared in multiple APIs and we promote them through dev->stage->prod environments. This creates a lot of work as each API needs to be updated with the new plugin ID in each environment following each new update to the plugin. The ability to update the existing plugin saves us from much of this work.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
